### PR TITLE
World icons, cropping instead of stretching screenshots, preventing mouse movement during load

### DIFF
--- a/src/main/java/com/tttsaurus/fluxloading/FluxLoading.java
+++ b/src/main/java/com/tttsaurus/fluxloading/FluxLoading.java
@@ -1,6 +1,10 @@
 package com.tttsaurus.fluxloading;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.util.ResourceLocation;
+
 import org.apache.logging.log4j.Logger;
 
 import com.tttsaurus.fluxloading.proxy.CommonProxy;
@@ -10,9 +14,6 @@ import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Mod(
     modid = "fluxloading",

--- a/src/main/java/com/tttsaurus/fluxloading/FluxLoading.java
+++ b/src/main/java/com/tttsaurus/fluxloading/FluxLoading.java
@@ -24,6 +24,7 @@ public class FluxLoading {
 
     public static Logger logger;
     public static final Map<String, ResourceLocation> screenshotCache = new HashMap<>();
+    public static final ResourceLocation noThumbnailRl = new ResourceLocation("textures/misc/unknown_pack.png");
 
     @SidedProxy(
         clientSide = "com.tttsaurus.fluxloading.proxy.ClientProxy",

--- a/src/main/java/com/tttsaurus/fluxloading/FluxLoading.java
+++ b/src/main/java/com/tttsaurus/fluxloading/FluxLoading.java
@@ -1,5 +1,6 @@
 package com.tttsaurus.fluxloading;
 
+import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Logger;
 
 import com.tttsaurus.fluxloading.proxy.CommonProxy;
@@ -10,6 +11,9 @@ import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Mod(
     modid = "fluxloading",
     version = "0.0.1",
@@ -19,6 +23,7 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 public class FluxLoading {
 
     public static Logger logger;
+    public static final Map<String, ResourceLocation> screenshotCache = new HashMap<>();
 
     @SidedProxy(
         clientSide = "com.tttsaurus.fluxloading.proxy.ClientProxy",

--- a/src/main/java/com/tttsaurus/fluxloading/FluxLoadingConfig.java
+++ b/src/main/java/com/tttsaurus/fluxloading/FluxLoadingConfig.java
@@ -61,8 +61,15 @@ public class FluxLoadingConfig {
             ENABLE_DARK_OVERLAY = CONFIG
                 .getBoolean("Enable Dark Overlay", "shader", false, "An overlay on the screenshot");
 
-            ENABLE_THUMBNAIL = CONFIG.getBoolean("Enable Thumbnail", "thumbnail", true, "Enable world selection GUI thumbnails");
-            THUMBNAIL_SIZE = CONFIG.getInt("Thumbnail Resolution", "thumbnail", 512, 32, 4096, "Size of the world selection GUI thumbnail");
+            ENABLE_THUMBNAIL = CONFIG
+                .getBoolean("Enable Thumbnail", "thumbnail", true, "Enable world selection GUI thumbnails");
+            THUMBNAIL_SIZE = CONFIG.getInt(
+                "Thumbnail Resolution",
+                "thumbnail",
+                512,
+                32,
+                4096,
+                "Size of the world selection GUI thumbnail");
         } catch (Exception ignored) {} finally {
             if (CONFIG.hasChanged()) CONFIG.save();
         }

--- a/src/main/java/com/tttsaurus/fluxloading/FluxLoadingConfig.java
+++ b/src/main/java/com/tttsaurus/fluxloading/FluxLoadingConfig.java
@@ -14,6 +14,9 @@ public class FluxLoadingConfig {
     public static boolean ENABLE_DISSOLVING_EFFECT;
     public static boolean ENABLE_DARK_OVERLAY;
 
+    public static boolean ENABLE_THUMBNAIL;
+    public static int THUMBNAIL_SIZE;
+
     public static Configuration CONFIG;
 
     public static void loadConfig() {
@@ -57,6 +60,9 @@ public class FluxLoadingConfig {
                 .getBoolean("Enable Dissolving Effect", "shader", false, "A fade out option");
             ENABLE_DARK_OVERLAY = CONFIG
                 .getBoolean("Enable Dark Overlay", "shader", false, "An overlay on the screenshot");
+
+            ENABLE_THUMBNAIL = CONFIG.getBoolean("Enable Thumbnail", "thumbnail", true, "Enable world selection GUI thumbnails");
+            THUMBNAIL_SIZE = CONFIG.getInt("Thumbnail Resolution", "thumbnail", 512, 32, 4096, "Size of the world selection GUI thumbnail");
         } catch (Exception ignored) {} finally {
             if (CONFIG.hasChanged()) CONFIG.save();
         }

--- a/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
+++ b/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
@@ -66,6 +66,8 @@ public final class WorldLoadingScreenOverhaul {
     private static SmoothDamp smoothDamp = null;
     private static double prevFadeOutTime = 0d;
 
+    public static boolean freezePlayer = false;
+
     public static final String LAST_SCREENSHOT_NAME = "last_screenshot";
     public static final String THUMBNAIL_NAME = "thumbnail";
 
@@ -156,6 +158,8 @@ public final class WorldLoadingScreenOverhaul {
     }
 
     public static void startFadeOutTimer() {
+        freezePlayer = true;
+        Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
         fadeOutStopWatch = new StopWatch();
         fadeOutStopWatch.start();
         smoothDamp = new SmoothDamp(0, 1, (float) fadeOutDuration);
@@ -167,6 +171,8 @@ public final class WorldLoadingScreenOverhaul {
             fadeOutStopWatch.stop();
             fadeOutStopWatch = null;
         }
+        freezePlayer = false;
+        Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
     }
 
     public static BufferedImage getScreenShot() {
@@ -317,9 +323,13 @@ public final class WorldLoadingScreenOverhaul {
         if (screenShotToggle) {
             screenShotToggle = false;
             Minecraft minecraft = Minecraft.getMinecraft();
-            screenShot = ScreenshotHelper.saveScreenshotArbitrarySize(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+            screenShot = ScreenshotHelper
+                .saveScreenshotArbitrarySize(minecraft, minecraft.displayWidth, minecraft.displayHeight);
 
-            BufferedImage thumbnail = ScreenshotHelper.saveScreenshotArbitrarySize(minecraft, FluxLoadingConfig.THUMBNAIL_SIZE, FluxLoadingConfig.THUMBNAIL_SIZE);
+            BufferedImage thumbnail = ScreenshotHelper.saveScreenshotArbitrarySize(
+                minecraft,
+                FluxLoadingConfig.THUMBNAIL_SIZE,
+                FluxLoadingConfig.THUMBNAIL_SIZE);
             trySaveToLocal(thumbnail, THUMBNAIL_NAME);
         }
     }

--- a/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
+++ b/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
@@ -1,11 +1,16 @@
 package com.tttsaurus.fluxloading.core;
 
+import static com.tttsaurus.fluxloading.util.ScreenshotHelper.scaleAndCropToResolution;
+
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
+
+import javax.imageio.ImageIO;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
@@ -172,13 +177,51 @@ public final class WorldLoadingScreenOverhaul {
         }
     }
 
+    /*
+     * public static void tryReadFromLocal(String folderName) {
+     * File screenshot = new File("saves/" + folderName + "/last_screenshot.png");
+     * if (screenshot.exists()) {
+     * Texture2D texture = RenderUtils.readPng(screenshot);
+     * if (texture != null) updateTexture(texture);
+     * }
+     * }
+     */
     public static void tryReadFromLocal(String folderName) {
         File screenshot = new File("saves/" + folderName + "/last_screenshot.png");
         if (screenshot.exists()) {
-            Texture2D texture = RenderUtils.readPng(screenshot);
-            if (texture != null) updateTexture(texture);
+            BufferedImage image = null;
+            try {
+                image = ImageIO.read(screenshot);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            if (image != null) {
+                int targetW = Minecraft.getMinecraft().displayWidth;
+                int targetH = Minecraft.getMinecraft().displayHeight;
+
+                BufferedImage adapted = scaleAndCropToResolution(image, targetW, targetH);
+
+                int[] pixels = new int[targetW * targetH];
+                adapted.getRGB(0, 0, targetW, targetH, pixels, 0, targetW);
+
+                ByteBuffer buffer = ByteBuffer.allocateDirect(targetW * targetH * 4);
+                for (int y = 0; y < targetH; y++) {
+                    for (int x = 0; x < targetW; x++) {
+                        int pixel = pixels[y * targetW + x];
+                        buffer.put((byte) ((pixel >> 16) & 0xFF)); // Red
+                        buffer.put((byte) ((pixel >> 8) & 0xFF)); // Green
+                        buffer.put((byte) (pixel & 0xFF)); // Blue
+                        buffer.put((byte) ((pixel >> 24) & 0xFF)); // Alpha
+                    }
+                }
+                buffer.flip();
+
+                Texture2D texture = new Texture2D(targetW, targetH, buffer);
+                if (texture != null) updateTexture(texture);
+            }
         }
     }
+
     // </editor-fold>
 
     public static void drawOverlay() {
@@ -273,8 +316,9 @@ public final class WorldLoadingScreenOverhaul {
         if (screenShotToggle) {
             screenShotToggle = false;
             Minecraft minecraft = Minecraft.getMinecraft();
-            screenShot = ScreenshotHelper
-                .saveScreenshot(minecraft.displayWidth, minecraft.displayHeight, minecraft.getFramebuffer());
+            // screenShot = ScreenshotHelper
+            // .saveScreenshot(minecraft.displayWidth, minecraft.displayHeight, minecraft.getFramebuffer());
+            screenShot = ScreenshotHelper.saveScreenshot2(minecraft, 1080, 1080);
         }
     }
 

--- a/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
+++ b/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
@@ -66,6 +66,9 @@ public final class WorldLoadingScreenOverhaul {
     private static SmoothDamp smoothDamp = null;
     private static double prevFadeOutTime = 0d;
 
+    public static final String LAST_SCREENSHOT_NAME = "last_screenshot";
+    public static final String THUMBNAIL_NAME = "thumbnail";
+
     // <editor-fold desc="getters & setters">
     public static void prepareScreenShot() {
         screenShotToggle = true;
@@ -165,31 +168,27 @@ public final class WorldLoadingScreenOverhaul {
             fadeOutStopWatch = null;
         }
     }
+
+    public static BufferedImage getScreenShot() {
+        return screenShot;
+    }
     // </editor-fold>
 
     // <editor-fold desc="save & read">
-    public static void trySaveToLocal() {
+    public static void trySaveToLocal(BufferedImage screenShot, String name) {
         IntegratedServer server = Minecraft.getMinecraft()
             .getIntegratedServer();
         if (server != null) {
             File worldSaveDir = new File("saves/" + server.getFolderName());
-            if (screenShot != null) RenderUtils.createPng(worldSaveDir, "last_screenshot", screenShot);
+            if (screenShot != null) RenderUtils.createPng(worldSaveDir, name, screenShot);
         }
     }
 
-    /*
-     * public static void tryReadFromLocal(String folderName) {
-     * File screenshot = new File("saves/" + folderName + "/last_screenshot.png");
-     * if (screenshot.exists()) {
-     * Texture2D texture = RenderUtils.readPng(screenshot);
-     * if (texture != null) updateTexture(texture);
-     * }
-     * }
-     */
-    public static void tryReadFromLocal(String folderName) {
-        File screenshot = new File("saves/" + folderName + "/last_screenshot.png");
+    /* Scale and crop if necessary to avoid stretched screenshots */
+    public static void tryReadFromLocalLast(String folderName) {
+        File screenshot = new File("saves/" + folderName + "/" + LAST_SCREENSHOT_NAME + ".png");
         if (screenshot.exists()) {
-            BufferedImage image = null;
+            BufferedImage image;
             try {
                 image = ImageIO.read(screenshot);
             } catch (IOException e) {
@@ -217,7 +216,7 @@ public final class WorldLoadingScreenOverhaul {
                 buffer.flip();
 
                 Texture2D texture = new Texture2D(targetW, targetH, buffer);
-                if (texture != null) updateTexture(texture);
+                updateTexture(texture);
             }
         }
     }
@@ -276,6 +275,7 @@ public final class WorldLoadingScreenOverhaul {
         else GlStateManager.disableBlend();
     }
 
+    @SuppressWarnings("unused")
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRenderGameOverlay(RenderGameOverlayEvent.Post event) {
         if (event.type != RenderGameOverlayEvent.ElementType.ALL) return;
@@ -311,14 +311,16 @@ public final class WorldLoadingScreenOverhaul {
         }
     }
 
+    @SuppressWarnings("unused")
     @SubscribeEvent
     public void onRenderWorldLast(RenderWorldLastEvent event) {
         if (screenShotToggle) {
             screenShotToggle = false;
             Minecraft minecraft = Minecraft.getMinecraft();
-            // screenShot = ScreenshotHelper
-            // .saveScreenshot(minecraft.displayWidth, minecraft.displayHeight, minecraft.getFramebuffer());
-            screenShot = ScreenshotHelper.saveScreenshot2(minecraft, 1080, 1080);
+            screenShot = ScreenshotHelper.saveScreenshotArbitrarySize(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+
+            BufferedImage thumbnail = ScreenshotHelper.saveScreenshotArbitrarySize(minecraft, FluxLoadingConfig.THUMBNAIL_SIZE, FluxLoadingConfig.THUMBNAIL_SIZE);
+            trySaveToLocal(thumbnail, THUMBNAIL_NAME);
         }
     }
 

--- a/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
+++ b/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
@@ -69,7 +69,7 @@ public final class WorldLoadingScreenOverhaul {
     public static boolean freezePlayer = false;
 
     public static final String LAST_SCREENSHOT_NAME = "last_screenshot";
-    public static final String THUMBNAIL_NAME = "thumbnail";
+    public static final String THUMBNAIL_NAME = "icon";
 
     // <editor-fold desc="getters & setters">
     public static void prepareScreenShot() {

--- a/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
+++ b/src/main/java/com/tttsaurus/fluxloading/core/WorldLoadingScreenOverhaul.java
@@ -51,6 +51,7 @@ public final class WorldLoadingScreenOverhaul {
     private static boolean chunkBuildingTitle = false;
     private static Texture2D texture = null;
     private static BufferedImage screenShot = null;
+    private static BufferedImage thumbnail = null;
 
     // waiting chunk build
     private static boolean countingChunkLoaded = false;
@@ -159,7 +160,6 @@ public final class WorldLoadingScreenOverhaul {
 
     public static void startFadeOutTimer() {
         freezePlayer = true;
-        Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
         fadeOutStopWatch = new StopWatch();
         fadeOutStopWatch.start();
         smoothDamp = new SmoothDamp(0, 1, (float) fadeOutDuration);
@@ -172,11 +172,14 @@ public final class WorldLoadingScreenOverhaul {
             fadeOutStopWatch = null;
         }
         freezePlayer = false;
-        Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
     }
 
     public static BufferedImage getScreenShot() {
         return screenShot;
+    }
+
+    public static BufferedImage getThumbnail() {
+        return thumbnail;
     }
     // </editor-fold>
 
@@ -324,13 +327,11 @@ public final class WorldLoadingScreenOverhaul {
             screenShotToggle = false;
             Minecraft minecraft = Minecraft.getMinecraft();
             screenShot = ScreenshotHelper
-                .saveScreenshotArbitrarySize(minecraft, minecraft.displayWidth, minecraft.displayHeight);
-
-            BufferedImage thumbnail = ScreenshotHelper.saveScreenshotArbitrarySize(
-                minecraft,
+                .saveScreenshot(minecraft.displayWidth, minecraft.displayHeight, minecraft.getFramebuffer());
+            thumbnail = ScreenshotHelper.scaleAndCropToResolution(
+                screenShot,
                 FluxLoadingConfig.THUMBNAIL_SIZE,
                 FluxLoadingConfig.THUMBNAIL_SIZE);
-            trySaveToLocal(thumbnail, THUMBNAIL_NAME);
         }
     }
 

--- a/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
+++ b/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
@@ -1,0 +1,23 @@
+package com.tttsaurus.fluxloading.event;
+
+import com.tttsaurus.fluxloading.FluxLoading;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+import cpw.mods.fml.common.network.FMLNetworkEvent;
+
+public class PlayerEventHandler {
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public void onPlayerLeave(PlayerEvent.PlayerLoggedOutEvent e) {
+
+        FluxLoading.screenshotCache.clear();
+        FluxLoading.logger.debug("Cleared screenshot cache");
+    }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public void onPlayerLeaveFMLEvent(FMLNetworkEvent.ClientDisconnectionFromServerEvent e) {
+        FluxLoading.screenshotCache.clear();
+        FluxLoading.logger.debug("Cleared screenshot cache");
+    }
+}

--- a/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
+++ b/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
@@ -1,13 +1,16 @@
 package com.tttsaurus.fluxloading.event;
 
+import net.minecraftforge.client.event.RenderHandEvent;
+
 import com.tttsaurus.fluxloading.FluxLoading;
 import com.tttsaurus.fluxloading.util.ScreenshotHelper;
+
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.network.FMLNetworkEvent;
-import net.minecraftforge.client.event.RenderHandEvent;
 
 public class PlayerEventHandler {
+
     @SuppressWarnings("unused")
     @SubscribeEvent
     public void onPlayerLeave(PlayerEvent.PlayerLoggedOutEvent e) {
@@ -23,6 +26,7 @@ public class PlayerEventHandler {
         FluxLoading.logger.debug("Cleared screenshot cache");
     }
 
+    /* We need this because we create a new fbo which would have the hand */
     @SuppressWarnings("unused")
     @SubscribeEvent
     public void onRenderHand(RenderHandEvent event) {

--- a/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
+++ b/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
@@ -1,9 +1,11 @@
 package com.tttsaurus.fluxloading.event;
 
 import com.tttsaurus.fluxloading.FluxLoading;
+import com.tttsaurus.fluxloading.util.ScreenshotHelper;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.network.FMLNetworkEvent;
+import net.minecraftforge.client.event.RenderHandEvent;
 
 public class PlayerEventHandler {
     @SuppressWarnings("unused")
@@ -19,5 +21,13 @@ public class PlayerEventHandler {
     public void onPlayerLeaveFMLEvent(FMLNetworkEvent.ClientDisconnectionFromServerEvent e) {
         FluxLoading.screenshotCache.clear();
         FluxLoading.logger.debug("Cleared screenshot cache");
+    }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public void onRenderHand(RenderHandEvent event) {
+        if (ScreenshotHelper.suppressHandRendering) {
+            event.setCanceled(true);
+        }
     }
 }

--- a/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
+++ b/src/main/java/com/tttsaurus/fluxloading/event/PlayerEventHandler.java
@@ -1,9 +1,6 @@
 package com.tttsaurus.fluxloading.event;
 
-import net.minecraftforge.client.event.RenderHandEvent;
-
 import com.tttsaurus.fluxloading.FluxLoading;
-import com.tttsaurus.fluxloading.util.ScreenshotHelper;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
@@ -24,14 +21,5 @@ public class PlayerEventHandler {
     public void onPlayerLeaveFMLEvent(FMLNetworkEvent.ClientDisconnectionFromServerEvent e) {
         FluxLoading.screenshotCache.clear();
         FluxLoading.logger.debug("Cleared screenshot cache");
-    }
-
-    /* We need this because we create a new fbo which would have the hand */
-    @SuppressWarnings("unused")
-    @SubscribeEvent
-    public void onRenderHand(RenderHandEvent event) {
-        if (ScreenshotHelper.suppressHandRendering) {
-            event.setCanceled(true);
-        }
     }
 }

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/FluxLoadingLateMixinLoader.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/FluxLoadingLateMixinLoader.java
@@ -1,15 +1,17 @@
 package com.tttsaurus.fluxloading.mixin;
 
-import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
-import com.gtnewhorizon.gtnhmixins.LateMixin;
-import cpw.mods.fml.common.Loader;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
+import com.gtnewhorizon.gtnhmixins.LateMixin;
+
+import cpw.mods.fml.common.Loader;
+
 @LateMixin
 public class FluxLoadingLateMixinLoader implements ILateMixinLoader {
+
     @Override
     public String getMixinConfig() {
         return "mixins.fluxloading.late.json";

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/FMLClientHandlerMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/FMLClientHandlerMixin.java
@@ -37,7 +37,7 @@ public class FMLClientHandlerMixin {
             }
 
             // try load screenshot
-            WorldLoadingScreenOverhaul.tryReadFromLocal(dirName);
+            WorldLoadingScreenOverhaul.tryReadFromLocalLast(dirName);
 
             WorldLoadingScreenOverhaul.setFinishedLoadingChunks(false);
             WorldLoadingScreenOverhaul.resetChunkLoadedNum();

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/FMLClientHandlerMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/FMLClientHandlerMixin.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 
+@SuppressWarnings("unused")
 @Mixin(value = FMLClientHandler.class, remap = false)
 public class FMLClientHandlerMixin {
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiDownloadTerrainMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiDownloadTerrainMixin.java
@@ -9,6 +9,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 
+@SuppressWarnings("unused")
 @Mixin(GuiDownloadTerrain.class)
 public class GuiDownloadTerrainMixin {
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiScreenWorkingMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiScreenWorkingMixin.java
@@ -9,6 +9,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 
+@SuppressWarnings("unused")
 @Mixin(GuiScreenWorking.class)
 public class GuiScreenWorkingMixin {
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldAccessor.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldAccessor.java
@@ -1,0 +1,11 @@
+package com.tttsaurus.fluxloading.mixin.early;
+
+import net.minecraft.client.gui.GuiSelectWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(GuiSelectWorld.class)
+public interface GuiSelectWorldAccessor {
+    @Accessor
+    java.util.List getField_146639_s();
+}

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldAccessor.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldAccessor.java
@@ -1,11 +1,13 @@
 package com.tttsaurus.fluxloading.mixin.early;
 
 import net.minecraft.client.gui.GuiSelectWorld;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(GuiSelectWorld.class)
 public interface GuiSelectWorldAccessor {
+
     @Accessor
     java.util.List getField_146639_s();
 }

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldMixin.java
@@ -1,7 +1,11 @@
 package com.tttsaurus.fluxloading.mixin.early;
 
+import com.tttsaurus.fluxloading.FluxLoading;
+import com.tttsaurus.fluxloading.FluxLoadingConfig;
+import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 import com.tttsaurus.fluxloading.util.ScreenshotHelper;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiSelectWorld;
 import net.minecraft.client.renderer.Tessellator;
@@ -13,8 +17,10 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@SuppressWarnings("unused")
 @Mixin(targets = "net.minecraft.client.gui.GuiSelectWorld$List")
 public class GuiSelectWorldMixin {
 
@@ -24,10 +30,7 @@ public class GuiSelectWorldMixin {
             index = 2 // p_148126_2_
     )
     private int modifyDrawSlotX(int original) {
-        //SaveFormatComparator saveformatcomparator = (SaveFormatComparator)((GuiSelectWorld)(Object)this).field_146639_s.get(p_148126_1_);
-        //String s = saveformatcomparator.getDisplayName();
-
-        return original + 36; // or whatever modification you need
+        return FluxLoadingConfig.ENABLE_THUMBNAIL ? original + 36 : original;
     }
 
     @Shadow(remap = false)
@@ -42,25 +45,23 @@ public class GuiSelectWorldMixin {
             int index, int x, int y, int height,
             Tessellator tessellator, int mouseX, int mouseY,
             CallbackInfo ci) {
-
-        //GuiSelectWorld screen = Minecraft.getMinecraft().currentScreen instanceof GuiSelectWorld
-        //        ? (GuiSelectWorld) Minecraft.getMinecraft().currentScreen : null;
-
-        //if (screen == null) return;
-
-        // Get the world list and folder name
+        if (!FluxLoadingConfig.ENABLE_THUMBNAIL) {
+            return;
+        }
         java.util.List saves = ((GuiSelectWorldAccessor)this$0).getField_146639_s();
         if (index < 0 || index >= saves.size()) return;
 
         SaveFormatComparator save = (SaveFormatComparator) saves.get(index);
         String folderName = save.getFileName();
 
-        ResourceLocation screenshot = ScreenshotHelper.getOrLoadScreenshot(folderName);
+        ResourceLocation screenshot = ScreenshotHelper.getOrLoadScreenshot(folderName, WorldLoadingScreenOverhaul.THUMBNAIL_NAME, FluxLoadingConfig.THUMBNAIL_SIZE, FluxLoadingConfig.THUMBNAIL_SIZE);
+        Minecraft mc = Minecraft.getMinecraft();
         if (screenshot != null) {
-            Minecraft mc = Minecraft.getMinecraft();
             mc.getTextureManager().bindTexture(screenshot);
-            Gui.func_146110_a(x - 36, y, 0, 0, 32, 32, 32, 32);
+        } else {
+            mc.getTextureManager().bindTexture(FluxLoading.noThumbnailRl);
         }
+        Gui.func_146110_a(x - 36, y, 0, 0, 32, 32, 32, 32);
     }
 }
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldMixin.java
@@ -1,0 +1,66 @@
+package com.tttsaurus.fluxloading.mixin.early;
+
+import com.tttsaurus.fluxloading.util.ScreenshotHelper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiSelectWorld;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.SaveFormatComparator;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.gui.GuiSelectWorld$List")
+public class GuiSelectWorldMixin {
+
+    @ModifyVariable(
+            method = "drawSlot(IIIILnet/minecraft/client/renderer/Tessellator;II)V",
+            at = @At("HEAD"),
+            index = 2 // p_148126_2_
+    )
+    private int modifyDrawSlotX(int original) {
+        //SaveFormatComparator saveformatcomparator = (SaveFormatComparator)((GuiSelectWorld)(Object)this).field_146639_s.get(p_148126_1_);
+        //String s = saveformatcomparator.getDisplayName();
+
+        return original + 36; // or whatever modification you need
+    }
+
+    @Shadow(remap = false)
+    @Final
+    GuiSelectWorld this$0;
+
+    @Inject(
+            method = "drawSlot(IIIILnet/minecraft/client/renderer/Tessellator;II)V",
+            at = @At("HEAD")
+    )
+    private void onDrawSlot(
+            int index, int x, int y, int height,
+            Tessellator tessellator, int mouseX, int mouseY,
+            CallbackInfo ci) {
+
+        //GuiSelectWorld screen = Minecraft.getMinecraft().currentScreen instanceof GuiSelectWorld
+        //        ? (GuiSelectWorld) Minecraft.getMinecraft().currentScreen : null;
+
+        //if (screen == null) return;
+
+        // Get the world list and folder name
+        java.util.List saves = ((GuiSelectWorldAccessor)this$0).getField_146639_s();
+        if (index < 0 || index >= saves.size()) return;
+
+        SaveFormatComparator save = (SaveFormatComparator) saves.get(index);
+        String folderName = save.getFileName();
+
+        ResourceLocation screenshot = ScreenshotHelper.getOrLoadScreenshot(folderName);
+        if (screenshot != null) {
+            Minecraft mc = Minecraft.getMinecraft();
+            mc.getTextureManager().bindTexture(screenshot);
+            Gui.func_146110_a(x - 36, y, 0, 0, 32, 32, 32, 32);
+        }
+    }
+}
+

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/GuiSelectWorldMixin.java
@@ -1,33 +1,30 @@
 package com.tttsaurus.fluxloading.mixin.early;
 
-import com.tttsaurus.fluxloading.FluxLoading;
-import com.tttsaurus.fluxloading.FluxLoadingConfig;
-import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
-import com.tttsaurus.fluxloading.util.ScreenshotHelper;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiSelectWorld;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.storage.SaveFormatComparator;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.tttsaurus.fluxloading.FluxLoading;
+import com.tttsaurus.fluxloading.FluxLoadingConfig;
+import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
+import com.tttsaurus.fluxloading.util.ScreenshotHelper;
 
 @SuppressWarnings("unused")
 @Mixin(targets = "net.minecraft.client.gui.GuiSelectWorld$List")
 public class GuiSelectWorldMixin {
 
-    @ModifyVariable(
-            method = "drawSlot(IIIILnet/minecraft/client/renderer/Tessellator;II)V",
-            at = @At("HEAD"),
-            index = 2 // p_148126_2_
+    @ModifyVariable(method = "drawSlot(IIIILnet/minecraft/client/renderer/Tessellator;II)V", at = @At("HEAD"), index = 2 // p_148126_2_
     )
     private int modifyDrawSlotX(int original) {
         return FluxLoadingConfig.ENABLE_THUMBNAIL ? original + 36 : original;
@@ -37,31 +34,31 @@ public class GuiSelectWorldMixin {
     @Final
     GuiSelectWorld this$0;
 
-    @Inject(
-            method = "drawSlot(IIIILnet/minecraft/client/renderer/Tessellator;II)V",
-            at = @At("HEAD")
-    )
-    private void onDrawSlot(
-            int index, int x, int y, int height,
-            Tessellator tessellator, int mouseX, int mouseY,
-            CallbackInfo ci) {
+    @Inject(method = "drawSlot(IIIILnet/minecraft/client/renderer/Tessellator;II)V", at = @At("HEAD"))
+    private void onDrawSlot(int index, int x, int y, int height, Tessellator tessellator, int mouseX, int mouseY,
+        CallbackInfo ci) {
         if (!FluxLoadingConfig.ENABLE_THUMBNAIL) {
             return;
         }
-        java.util.List saves = ((GuiSelectWorldAccessor)this$0).getField_146639_s();
+        java.util.List saves = ((GuiSelectWorldAccessor) this$0).getField_146639_s();
         if (index < 0 || index >= saves.size()) return;
 
         SaveFormatComparator save = (SaveFormatComparator) saves.get(index);
         String folderName = save.getFileName();
 
-        ResourceLocation screenshot = ScreenshotHelper.getOrLoadScreenshot(folderName, WorldLoadingScreenOverhaul.THUMBNAIL_NAME, FluxLoadingConfig.THUMBNAIL_SIZE, FluxLoadingConfig.THUMBNAIL_SIZE);
+        ResourceLocation screenshot = ScreenshotHelper.getOrLoadScreenshot(
+            folderName,
+            WorldLoadingScreenOverhaul.THUMBNAIL_NAME,
+            FluxLoadingConfig.THUMBNAIL_SIZE,
+            FluxLoadingConfig.THUMBNAIL_SIZE);
         Minecraft mc = Minecraft.getMinecraft();
         if (screenshot != null) {
-            mc.getTextureManager().bindTexture(screenshot);
+            mc.getTextureManager()
+                .bindTexture(screenshot);
         } else {
-            mc.getTextureManager().bindTexture(FluxLoading.noThumbnailRl);
+            mc.getTextureManager()
+                .bindTexture(FluxLoading.noThumbnailRl);
         }
         Gui.func_146110_a(x - 36, y, 0, 0, 32, 32, 32, 32);
     }
 }
-

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/LoadingScreenRendererMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/LoadingScreenRendererMixin.java
@@ -1,6 +1,5 @@
 package com.tttsaurus.fluxloading.mixin.early;
 
-import com.tttsaurus.fluxloading.util.MixinHelpers;
 import net.minecraft.client.LoadingScreenRenderer;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.Tessellator;
@@ -10,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.tttsaurus.fluxloading.util.MixinHelpers;
 
 @Mixin(LoadingScreenRenderer.class)
 public class LoadingScreenRendererMixin {

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/LoadingScreenRendererMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/LoadingScreenRendererMixin.java
@@ -11,6 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tttsaurus.fluxloading.util.MixinHelpers;
 
+@SuppressWarnings("unused")
 @Mixin(LoadingScreenRenderer.class)
 public class LoadingScreenRendererMixin {
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
@@ -25,6 +25,7 @@ public class MinecraftMixin {
         FluxLoading.logger.info("OpenGL resources disposed");
     }
 
+    @SuppressWarnings("unused")
     @Inject(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At("HEAD"))
     public void loadWorld(WorldClient worldClientIn, String loadingMessage, CallbackInfo ci) {
         WorldClient world = Minecraft.getMinecraft().theWorld;
@@ -33,10 +34,11 @@ public class MinecraftMixin {
             WorldLoadingScreenOverhaul.setDrawOverlay(false);
 
             // try save screenshot
-            WorldLoadingScreenOverhaul.trySaveToLocal();
+            WorldLoadingScreenOverhaul.trySaveToLocal(WorldLoadingScreenOverhaul.getScreenShot(), WorldLoadingScreenOverhaul.LAST_SCREENSHOT_NAME);
         }
     }
 
+    @SuppressWarnings("unused")
     @WrapOperation(
         method = "displayInGameMenu",
         at = @At(

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
@@ -34,7 +34,9 @@ public class MinecraftMixin {
             WorldLoadingScreenOverhaul.setDrawOverlay(false);
 
             // try save screenshot
-            WorldLoadingScreenOverhaul.trySaveToLocal(WorldLoadingScreenOverhaul.getScreenShot(), WorldLoadingScreenOverhaul.LAST_SCREENSHOT_NAME);
+            WorldLoadingScreenOverhaul.trySaveToLocal(
+                WorldLoadingScreenOverhaul.getScreenShot(),
+                WorldLoadingScreenOverhaul.LAST_SCREENSHOT_NAME);
         }
     }
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
@@ -37,6 +37,8 @@ public class MinecraftMixin {
             WorldLoadingScreenOverhaul.trySaveToLocal(
                 WorldLoadingScreenOverhaul.getScreenShot(),
                 WorldLoadingScreenOverhaul.LAST_SCREENSHOT_NAME);
+            WorldLoadingScreenOverhaul
+                .trySaveToLocal(WorldLoadingScreenOverhaul.getThumbnail(), WorldLoadingScreenOverhaul.THUMBNAIL_NAME);
         }
     }
 

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MinecraftMixin.java
@@ -15,6 +15,7 @@ import com.tttsaurus.fluxloading.FluxLoading;
 import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 import com.tttsaurus.fluxloading.render.GlResourceManager;
 
+@SuppressWarnings("unused")
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
 
@@ -25,7 +26,6 @@ public class MinecraftMixin {
         FluxLoading.logger.info("OpenGL resources disposed");
     }
 
-    @SuppressWarnings("unused")
     @Inject(method = "loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At("HEAD"))
     public void loadWorld(WorldClient worldClientIn, String loadingMessage, CallbackInfo ci) {
         WorldClient world = Minecraft.getMinecraft().theWorld;
@@ -40,7 +40,6 @@ public class MinecraftMixin {
         }
     }
 
-    @SuppressWarnings("unused")
     @WrapOperation(
         method = "displayInGameMenu",
         at = @At(

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinMouseHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinMouseHelper.java
@@ -1,0 +1,25 @@
+package com.tttsaurus.fluxloading.mixin.early;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.MouseHelper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
+
+@SuppressWarnings("unused")
+@Mixin(MouseHelper.class)
+public class MixinMouseHelper {
+
+    @Inject(method = "mouseXYChange", at = @At("HEAD"), cancellable = true)
+    public void onMouseXYChange(CallbackInfo ci) {
+        if (WorldLoadingScreenOverhaul.freezePlayer) {
+            Minecraft.getMinecraft().mouseHelper.deltaX = 0;
+            Minecraft.getMinecraft().mouseHelper.deltaY = 0;
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinWorldRenderer.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinWorldRenderer.java
@@ -11,7 +11,8 @@ import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 
 @Mixin(WorldRenderer.class)
 public class MixinWorldRenderer {
-    // This will get loaded and then later overwritten by Sodium if it is present, so we don't need to worry about conditionally loading it.
+    // This will get loaded and then later overwritten by Sodium if it is present, so we don't need to worry about
+    // conditionally loading it.
 
     @Inject(method = "updateRenderer", at = @At("RETURN"))
     public void updateRenderer(CallbackInfo ci) {

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinWorldRenderer.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinWorldRenderer.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 
+@SuppressWarnings("unused")
 @Mixin(WorldRenderer.class)
 public class MixinWorldRenderer {
     // This will get loaded and then later overwritten by Sodium if it is present, so we don't need to worry about

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinAetherLoadingScreen.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinAetherLoadingScreen.java
@@ -1,36 +1,40 @@
 package com.tttsaurus.fluxloading.mixin.late;
 
-import com.gildedgames.the_aether.client.gui.AetherLoadingScreen;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.tttsaurus.fluxloading.util.MixinHelpers;
 import net.minecraft.client.LoadingScreenRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.Tessellator;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+import com.gildedgames.the_aether.client.gui.AetherLoadingScreen;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.tttsaurus.fluxloading.util.MixinHelpers;
+
 @Mixin(AetherLoadingScreen.class)
 public class MixinAetherLoadingScreen extends LoadingScreenRenderer {
+
     public MixinAetherLoadingScreen(Minecraft p_i1017_1_) {
         super(p_i1017_1_);
     }
+
     @WrapOperation(
-            method = "setLoadingProgress",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;draw()I", ordinal = 0))
+        method = "setLoadingProgress",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;draw()I", ordinal = 0))
     public int mixin_setLoadingProgress_Tessellator$draw(Tessellator instance, Operation<Integer> original) {
         return MixinHelpers.mixinSetLoadingProgress$draw(Tessellator.instance, original);
     }
 
     @WrapOperation(
-            method = "setLoadingProgress",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
-                    ordinal = 0))
+        method = "setLoadingProgress",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
+            ordinal = 0))
     public int mixin_setLoadingProgress_FontRenderer$drawStringWithShadow(FontRenderer instance, String text, int x,
-                                                                          int y, int color, Operation<Integer> original) {
+        int y, int color, Operation<Integer> original) {
         return MixinHelpers.mixinSetLoadingProgress$drawStringWithShadow(instance, text, x, y, color, original);
     }
 }

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinLoadingScreen_LoadingScreenMessages.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinLoadingScreen_LoadingScreenMessages.java
@@ -1,36 +1,41 @@
 package com.tttsaurus.fluxloading.mixin.late;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.tttsaurus.fluxloading.util.MixinHelpers;
 import net.minecraft.client.LoadingScreenRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.Tessellator;
+
 import org.spongepowered.asm.mixin.Mixin;
-import loading_screen_messages.client.gui.LoadingScreen;
 import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.tttsaurus.fluxloading.util.MixinHelpers;
+
+import loading_screen_messages.client.gui.LoadingScreen;
 
 @Mixin(LoadingScreen.class)
 public class MixinLoadingScreen_LoadingScreenMessages extends LoadingScreenRenderer {
+
     public MixinLoadingScreen_LoadingScreenMessages(Minecraft p_i1017_1_) {
         super(p_i1017_1_);
     }
+
     @WrapOperation(
-            method = "setLoadingProgress",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;draw()I", ordinal = 0))
+        method = "setLoadingProgress",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Tessellator;draw()I", ordinal = 0))
     public int mixin_setLoadingProgress_Tessellator$draw(Tessellator instance, Operation<Integer> original) {
         return MixinHelpers.mixinSetLoadingProgress$draw(Tessellator.instance, original);
     }
 
     @WrapOperation(
-            method = "setLoadingProgress",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
-                    ordinal = 0))
+        method = "setLoadingProgress",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
+            ordinal = 0))
     public int mixin_setLoadingProgress_FontRenderer$drawStringWithShadow(FontRenderer instance, String text, int x,
-                                                                          int y, int color, Operation<Integer> original) {
+        int y, int color, Operation<Integer> original) {
         return MixinHelpers.mixinSetLoadingProgress$drawStringWithShadow(instance, text, x, y, color, original);
     }
 }

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinSodiumWorldRenderer.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/late/MixinSodiumWorldRenderer.java
@@ -1,15 +1,22 @@
 package com.tttsaurus.fluxloading.mixin.late;
 
-import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
-import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
+
+import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
+
 @Mixin(value = SodiumWorldRenderer.class, remap = false)
 public class MixinSodiumWorldRenderer {
-    @Inject(method = "drawChunkLayer", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager;renderLayer(Lcom/gtnewhorizons/angelica/compat/toremove/MatrixStack;Lme/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass;DDD)V"))
+
+    @Inject(
+        method = "drawChunkLayer",
+        at = @At(
+            value = "INVOKE",
+            target = "Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager;renderLayer(Lcom/gtnewhorizons/angelica/compat/toremove/MatrixStack;Lme/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass;DDD)V"))
     public void onDrawChunkLayer(CallbackInfo ci) {
         WorldLoadingScreenOverhaul.onChunkRendered();
     }

--- a/src/main/java/com/tttsaurus/fluxloading/proxy/ClientProxy.java
+++ b/src/main/java/com/tttsaurus/fluxloading/proxy/ClientProxy.java
@@ -1,7 +1,5 @@
 package com.tttsaurus.fluxloading.proxy;
 
-import com.tttsaurus.fluxloading.event.PlayerEventHandler;
-import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 
@@ -9,7 +7,9 @@ import org.apache.logging.log4j.Logger;
 
 import com.tttsaurus.fluxloading.FluxLoadingConfig;
 import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
+import com.tttsaurus.fluxloading.event.PlayerEventHandler;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 
@@ -30,8 +30,8 @@ public class ClientProxy extends CommonProxy {
         PlayerEventHandler playerEventHandler = new PlayerEventHandler();
         MinecraftForge.EVENT_BUS.register(playerEventHandler);
         FMLCommonHandler.instance()
-                .bus()
-                .register(playerEventHandler);
+            .bus()
+            .register(playerEventHandler);
     }
 
     @Override

--- a/src/main/java/com/tttsaurus/fluxloading/proxy/ClientProxy.java
+++ b/src/main/java/com/tttsaurus/fluxloading/proxy/ClientProxy.java
@@ -1,5 +1,7 @@
 package com.tttsaurus.fluxloading.proxy;
 
+import com.tttsaurus.fluxloading.event.PlayerEventHandler;
+import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 
@@ -24,6 +26,12 @@ public class ClientProxy extends CommonProxy {
         WorldLoadingScreenOverhaul.setTargetChunkNumCoefficient(FluxLoadingConfig.WAIT_CHUNK_BUILD_COEFFICIENT);
         WorldLoadingScreenOverhaul.setExtraWaitTime(FluxLoadingConfig.EXTRA_WAIT_TIME);
         WorldLoadingScreenOverhaul.setFadeOutDuration(FluxLoadingConfig.FADE_OUT_DURATION);
+
+        PlayerEventHandler playerEventHandler = new PlayerEventHandler();
+        MinecraftForge.EVENT_BUS.register(playerEventHandler);
+        FMLCommonHandler.instance()
+                .bus()
+                .register(playerEventHandler);
     }
 
     @Override

--- a/src/main/java/com/tttsaurus/fluxloading/util/MixinHelpers.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/MixinHelpers.java
@@ -1,14 +1,17 @@
 package com.tttsaurus.fluxloading.util;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
-import com.tttsaurus.fluxloading.render.RenderUtils;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.resources.I18n;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
+import com.tttsaurus.fluxloading.render.RenderUtils;
+
 public class MixinHelpers {
-    public static int mixinSetLoadingProgress$drawStringWithShadow(FontRenderer instance, String text, int x, int y, int color, Operation<Integer> original) {
+
+    public static int mixinSetLoadingProgress$drawStringWithShadow(FontRenderer instance, String text, int x, int y,
+        int color, Operation<Integer> original) {
         int res = original.call(instance, text, x, y, color);
         if (WorldLoadingScreenOverhaul.getDrawOverlay()) {
             if (WorldLoadingScreenOverhaul.getForceLoadingTitle() && text != null && !text.isEmpty())

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -7,23 +7,24 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.IntBuffer;
 
-import com.tttsaurus.fluxloading.FluxLoading;
-import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
+import javax.imageio.ImageIO;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.shader.Framebuffer;
-
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import javax.imageio.ImageIO;
+import com.tttsaurus.fluxloading.FluxLoading;
 
 @SuppressWarnings("DuplicatedCode")
 public class ScreenshotHelper {
+
     public static boolean suppressHandRendering = false;
 
     // Code adapted from Minecraft's ScreenshotHelper class
@@ -86,7 +87,8 @@ public class ScreenshotHelper {
 
     public static BufferedImage saveScreenshotArbitrarySize(Minecraft mc, int width, int height) {
         suppressHandRendering = true;
-        System.out.println("Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
+        System.out.println(
+            "Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
         int originalWidth = mc.displayWidth;
         int originalHeight = mc.displayHeight;
 
@@ -142,10 +144,13 @@ public class ScreenshotHelper {
         return output;
     }
 
-    public static ResourceLocation getOrLoadScreenshot(String worldName, String screenShotName, int targetWidth, int targetHeight) {
+    public static ResourceLocation getOrLoadScreenshot(String worldName, String screenShotName, int targetWidth,
+        int targetHeight) {
         String cacheKey = worldName + "_" + screenShotName;
         return FluxLoading.screenshotCache.computeIfAbsent(cacheKey, key -> {
-            File screenshot = new File(Minecraft.getMinecraft().mcDataDir, "saves/" + worldName + "/" + screenShotName + ".png");
+            File screenshot = new File(
+                Minecraft.getMinecraft().mcDataDir,
+                "saves/" + worldName + "/" + screenShotName + ".png");
             if (!screenshot.exists()) return null;
 
             try {
@@ -159,8 +164,9 @@ public class ScreenshotHelper {
 
                 DynamicTexture texture = new DynamicTexture(resized);
 
-                return Minecraft.getMinecraft().getTextureManager()
-                        .getDynamicTextureLocation("screenshot_" + cacheKey, texture);
+                return Minecraft.getMinecraft()
+                    .getTextureManager()
+                    .getDynamicTextureLocation("screenshot_" + cacheKey, texture);
             } catch (IOException e) {
                 FluxLoading.logger.error(e.getMessage(), e);
                 return null;

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -1,8 +1,11 @@
 package com.tttsaurus.fluxloading.util;
 
+import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.nio.IntBuffer;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.shader.Framebuffer;
@@ -70,4 +73,63 @@ public class ScreenshotHelper {
         }
         return bufferedimage;
     }
+
+    public static BufferedImage saveScreenshot2(Minecraft mc, int width, int height) {
+        int originalWidth = mc.displayWidth;
+        int originalHeight = mc.displayHeight;
+
+        int targetWidth = width;
+        int targetHeight = height;
+
+        Framebuffer fbo = new Framebuffer(targetWidth, targetHeight, true);
+        fbo.bindFramebuffer(false);
+
+        mc.displayWidth = targetWidth;
+        mc.displayHeight = targetHeight;
+
+        mc.getFramebuffer()
+            .unbindFramebuffer();
+        mc.resize(targetWidth, targetHeight);
+        mc.entityRenderer.updateCameraAndRender(0);
+
+        fbo.bindFramebuffer(true);
+        mc.entityRenderer.updateCameraAndRender(0);
+
+        BufferedImage screenshot = ScreenshotHelper.saveScreenshot(targetWidth, targetHeight, fbo);
+
+        fbo.unbindFramebuffer();
+        fbo.deleteFramebuffer();
+
+        mc.displayWidth = originalWidth;
+        mc.displayHeight = originalHeight;
+        mc.resize(originalWidth, originalHeight);
+        mc.getFramebuffer()
+            .bindFramebuffer(false);
+
+        return screenshot;
+    }
+
+    public static BufferedImage scaleAndCropToResolution(BufferedImage source, int targetWidth, int targetHeight) {
+        int srcWidth = source.getWidth();
+        int srcHeight = source.getHeight();
+
+        double scale = Math.max((double) targetWidth / srcWidth, (double) targetHeight / srcHeight);
+
+        int scaledWidth = (int) (scale * srcWidth);
+        int scaledHeight = (int) (scale * srcHeight);
+
+        Image scaled = source.getScaledInstance(scaledWidth, scaledHeight, Image.SCALE_SMOOTH);
+
+        BufferedImage output = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = output.createGraphics();
+
+        int x = (scaledWidth - targetWidth) / 2;
+        int y = (scaledHeight - targetHeight) / 2;
+
+        g2d.drawImage(scaled, -x, -y, null);
+        g2d.dispose();
+
+        return output;
+    }
+
 }

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -24,6 +24,8 @@ import javax.imageio.ImageIO;
 
 @SuppressWarnings("DuplicatedCode")
 public class ScreenshotHelper {
+    public static boolean suppressHandRendering = false;
+
     // Code adapted from Minecraft's ScreenshotHelper class
     // Copyright Mojang Studios, 2010-2025.
 
@@ -83,6 +85,7 @@ public class ScreenshotHelper {
     }
 
     public static BufferedImage saveScreenshotArbitrarySize(Minecraft mc, int width, int height) {
+        suppressHandRendering = true;
         System.out.println("Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
         int originalWidth = mc.displayWidth;
         int originalHeight = mc.displayHeight;
@@ -112,6 +115,7 @@ public class ScreenshotHelper {
         mc.getFramebuffer()
             .bindFramebuffer(false);
 
+        suppressHandRendering = false;
         return screenshot;
     }
 

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.IntBuffer;
 
 import com.tttsaurus.fluxloading.FluxLoading;
+import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.texture.DynamicTexture;
@@ -81,28 +82,26 @@ public class ScreenshotHelper {
         return bufferedimage;
     }
 
-    public static BufferedImage saveScreenshot2(Minecraft mc, int width, int height) {
+    public static BufferedImage saveScreenshotArbitrarySize(Minecraft mc, int width, int height) {
+        System.out.println("Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
         int originalWidth = mc.displayWidth;
         int originalHeight = mc.displayHeight;
 
-        int targetWidth = width;
-        int targetHeight = height;
-
-        Framebuffer fbo = new Framebuffer(targetWidth, targetHeight, true);
+        Framebuffer fbo = new Framebuffer(width, height, true);
         fbo.bindFramebuffer(false);
 
-        mc.displayWidth = targetWidth;
-        mc.displayHeight = targetHeight;
+        mc.displayWidth = width;
+        mc.displayHeight = height;
 
         mc.getFramebuffer()
             .unbindFramebuffer();
-        mc.resize(targetWidth, targetHeight);
+        mc.resize(width, height);
         mc.entityRenderer.updateCameraAndRender(0);
 
         fbo.bindFramebuffer(true);
         mc.entityRenderer.updateCameraAndRender(0);
 
-        BufferedImage screenshot = ScreenshotHelper.saveScreenshot(targetWidth, targetHeight, fbo);
+        BufferedImage screenshot = ScreenshotHelper.saveScreenshot(width, height, fbo);
 
         fbo.unbindFramebuffer();
         fbo.deleteFramebuffer();
@@ -139,27 +138,27 @@ public class ScreenshotHelper {
         return output;
     }
 
-    public static ResourceLocation getOrLoadScreenshot(String worldName) {
-        return FluxLoading.screenshotCache.computeIfAbsent(worldName, name -> {
-            File screenshot = new File(Minecraft.getMinecraft().mcDataDir, "saves/" + name + "/last_screenshot.png");
+    public static ResourceLocation getOrLoadScreenshot(String worldName, String screenShotName, int targetWidth, int targetHeight) {
+        String cacheKey = worldName + "_" + screenShotName;
+        return FluxLoading.screenshotCache.computeIfAbsent(cacheKey, key -> {
+            File screenshot = new File(Minecraft.getMinecraft().mcDataDir, "saves/" + worldName + "/" + screenShotName + ".png");
             if (!screenshot.exists()) return null;
 
             try {
                 BufferedImage image = ImageIO.read(screenshot);
                 if (image == null) return null;
 
-                BufferedImage resized = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+                BufferedImage resized = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB);
                 Graphics2D g = resized.createGraphics();
-                g.drawImage(image, 0, 0, 64, 64, null);
+                g.drawImage(image, 0, 0, targetWidth, targetHeight, null);
                 g.dispose();
 
                 DynamicTexture texture = new DynamicTexture(resized);
-                ResourceLocation resource = Minecraft.getMinecraft().getTextureManager()
-                        .getDynamicTextureLocation("screenshot_" + name, texture);
 
-                return resource;
+                return Minecraft.getMinecraft().getTextureManager()
+                        .getDynamicTextureLocation("screenshot_" + cacheKey, texture);
             } catch (IOException e) {
-                e.printStackTrace();
+                FluxLoading.logger.error(e.getMessage(), e);
                 return null;
             }
         });

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -3,16 +3,23 @@ package com.tttsaurus.fluxloading.util;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 import java.nio.IntBuffer;
 
+import com.tttsaurus.fluxloading.FluxLoading;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.shader.Framebuffer;
 
+import net.minecraft.util.ResourceLocation;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+
+import javax.imageio.ImageIO;
 
 @SuppressWarnings("DuplicatedCode")
 public class ScreenshotHelper {
@@ -132,4 +139,29 @@ public class ScreenshotHelper {
         return output;
     }
 
+    public static ResourceLocation getOrLoadScreenshot(String worldName) {
+        return FluxLoading.screenshotCache.computeIfAbsent(worldName, name -> {
+            File screenshot = new File(Minecraft.getMinecraft().mcDataDir, "saves/" + name + "/last_screenshot.png");
+            if (!screenshot.exists()) return null;
+
+            try {
+                BufferedImage image = ImageIO.read(screenshot);
+                if (image == null) return null;
+
+                BufferedImage resized = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+                Graphics2D g = resized.createGraphics();
+                g.drawImage(image, 0, 0, 64, 64, null);
+                g.dispose();
+
+                DynamicTexture texture = new DynamicTexture(resized);
+                ResourceLocation resource = Minecraft.getMinecraft().getTextureManager()
+                        .getDynamicTextureLocation("screenshot_" + name, texture);
+
+                return resource;
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        });
+    }
 }

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -24,9 +24,6 @@ import com.tttsaurus.fluxloading.FluxLoading;
 
 @SuppressWarnings("DuplicatedCode")
 public class ScreenshotHelper {
-
-    public static boolean suppressHandRendering = false;
-
     // Code adapted from Minecraft's ScreenshotHelper class
     // Copyright Mojang Studios, 2010-2025.
 
@@ -83,42 +80,6 @@ public class ScreenshotHelper {
             bufferedimage.setRGB(0, 0, p_148259_2_, p_148259_3_, pixelValues, 0, p_148259_2_);
         }
         return bufferedimage;
-    }
-
-    public static BufferedImage saveScreenshotArbitrarySize(Minecraft mc, int width, int height) {
-        suppressHandRendering = true;
-        FluxLoading.logger
-            .debug("Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
-        int originalWidth = mc.displayWidth;
-        int originalHeight = mc.displayHeight;
-
-        Framebuffer fbo = new Framebuffer(width, height, true);
-        fbo.bindFramebuffer(false);
-
-        mc.displayWidth = width;
-        mc.displayHeight = height;
-
-        mc.getFramebuffer()
-            .unbindFramebuffer();
-        mc.resize(width, height);
-        mc.entityRenderer.updateCameraAndRender(0);
-
-        fbo.bindFramebuffer(true);
-        mc.entityRenderer.updateCameraAndRender(0);
-
-        BufferedImage screenshot = ScreenshotHelper.saveScreenshot(width, height, fbo);
-
-        fbo.unbindFramebuffer();
-        fbo.deleteFramebuffer();
-
-        mc.displayWidth = originalWidth;
-        mc.displayHeight = originalHeight;
-        mc.resize(originalWidth, originalHeight);
-        mc.getFramebuffer()
-            .bindFramebuffer(false);
-
-        suppressHandRendering = false;
-        return screenshot;
     }
 
     public static BufferedImage scaleAndCropToResolution(BufferedImage source, int targetWidth, int targetHeight) {

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -87,8 +87,8 @@ public class ScreenshotHelper {
 
     public static BufferedImage saveScreenshotArbitrarySize(Minecraft mc, int width, int height) {
         suppressHandRendering = true;
-        FluxLoading.logger.debug(
-            "Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
+        FluxLoading.logger
+            .debug("Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
         int originalWidth = mc.displayWidth;
         int originalHeight = mc.displayHeight;
 

--- a/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
+++ b/src/main/java/com/tttsaurus/fluxloading/util/ScreenshotHelper.java
@@ -87,7 +87,7 @@ public class ScreenshotHelper {
 
     public static BufferedImage saveScreenshotArbitrarySize(Minecraft mc, int width, int height) {
         suppressHandRendering = true;
-        System.out.println(
+        FluxLoading.logger.debug(
             "Taking " + width + "x" + height + " screenshot (" + mc.displayWidth + "x" + mc.displayHeight + ")");
         int originalWidth = mc.displayWidth;
         int originalHeight = mc.displayHeight;

--- a/src/main/resources/assets/fluxloading/lang/de_DE.lang
+++ b/src/main/resources/assets/fluxloading/lang/de_DE.lang
@@ -1,0 +1,1 @@
+ fluxloading.loading_wait=Erstellung der Chunks

--- a/src/main/resources/assets/fluxloading/lang/fr_FR.lang
+++ b/src/main/resources/assets/fluxloading/lang/fr_FR.lang
@@ -1,0 +1,1 @@
+fluxloading.loading_wait=Construction des chunks

--- a/src/main/resources/assets/fluxloading/lang/pl_PL.lang
+++ b/src/main/resources/assets/fluxloading/lang/pl_PL.lang
@@ -1,0 +1,1 @@
+fluxloading.loading_wait=Budowanie chunków

--- a/src/main/resources/mixins.fluxloading.json
+++ b/src/main/resources/mixins.fluxloading.json
@@ -14,7 +14,8 @@
     "MinecraftMixin",
     "MixinWorldRenderer",
     "GuiSelectWorldAccessor",
-    "GuiSelectWorldMixin"
+    "GuiSelectWorldMixin",
+    "MixinMouseHelper"
   ],
   "server": []
 }

--- a/src/main/resources/mixins.fluxloading.json
+++ b/src/main/resources/mixins.fluxloading.json
@@ -12,7 +12,9 @@
     "GuiScreenWorkingMixin",
     "LoadingScreenRendererMixin",
     "MinecraftMixin",
-    "MixinWorldRenderer"
+    "MixinWorldRenderer",
+    "GuiSelectWorldAccessor",
+    "GuiSelectWorldMixin"
   ],
   "server": []
 }


### PR DESCRIPTION
* Added world icons, can be enabled/disabled in config
![image](https://github.com/user-attachments/assets/15048fe5-ba72-4031-ba80-01e6b1e8da31)
Also works in *MC launcher previews:
![image](https://github.com/user-attachments/assets/b8350809-45a1-491b-9473-e2943d832fd4)

* Added the functionality of cropping and centering a screenshot on load if the window size is different than what it was when the screenshot was made
* Added mouse movement prevention during fade out