### PR TITLE
remove gasstation reference in favor of gtnh mixin loader

### DIFF
--- a/src/main/java/com/tttsaurus/fluxloading/FluxLoadingCoremod.java
+++ b/src/main/java/com/tttsaurus/fluxloading/FluxLoadingCoremod.java
@@ -3,10 +3,11 @@ package com.tttsaurus.fluxloading;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import com.falsepattern.gasstation.IEarlyMixinLoader;
+import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 
@@ -40,11 +41,12 @@ public class FluxLoadingCoremod implements IFMLLoadingPlugin, IEarlyMixinLoader 
     }
 
     @Override
-    public List<String> getMixinConfigs() {
-        List<String> list = new ArrayList<>();
+    public String getMixinConfig() {
+        return "mixins.fluxloading.json";
+    }
 
-        list.add("mixins.fluxloading.json");
-
-        return list;
+    @Override
+    public List<String> getMixins(Set<String> loadedCoreMods) {
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinMinecraft.java
+++ b/src/main/java/com/tttsaurus/fluxloading/mixin/early/MixinMinecraft.java
@@ -1,6 +1,5 @@
 package com.tttsaurus.fluxloading.mixin.early;
 
-import com.tttsaurus.fluxloading.FluxLoadingConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.WorldClient;
@@ -13,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tttsaurus.fluxloading.FluxLoading;
+import com.tttsaurus.fluxloading.FluxLoadingConfig;
 import com.tttsaurus.fluxloading.core.WorldLoadingScreenOverhaul;
 import com.tttsaurus.fluxloading.render.GlResourceManager;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
misc

**What is the current behavior?** (You can also link to an open issue here)
uses gasstation mixin loader instead of gtnhmixins

**What is the new behavior (if this is a feature change)?**
uses gtnhmixins

**Does this PR introduce a breaking change?**
no

**Other information**:
see https://github.com/LegacyModdingMC/UniMixins/issues/49#issuecomment-3057872068